### PR TITLE
Handle localized Amazon wishlist URLs

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,5 @@
-The only difference between the chrome version and the firefox one is the manifest (v2 vs v3)
+The only difference between the chrome version and the firefox one is the manifest (v2 vs v3).
+
+This extension now supports localized Amazon wishlist URLs, including paths with
+segments like `-/en/hz/wishlist/ls/` so it works across different country and
+language variants.

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -6,10 +6,13 @@
   "permissions": ["activeTab", "storage", "https://www.amazon.es/"],
   "content_scripts": [
     {
-      "matches": ["*://*.amazon.com/hz/wishlist/ls/*", "*://*.amazon.es/hz/wishlist/ls/*"],
+      "matches": [
+        "*://*.amazon.com/*hz/wishlist/ls/*",
+        "*://*.amazon.es/*hz/wishlist/ls/*"
+      ],
       "js": ["content.js"]
     }
-  ],  
+  ],
   "background": {
     "service_worker": "background.js"
   },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,10 @@
   ],
   "content_scripts": [
     {
-      "matches": ["*://*.amazon.com/hz/wishlist/ls/*", "*://*.amazon.es/hz/wishlist/ls/*"],
+      "matches": [
+        "*://*.amazon.com/*hz/wishlist/ls/*",
+        "*://*.amazon.es/*hz/wishlist/ls/*"
+      ],
       "js": ["content.js"]
     }
   ],


### PR DESCRIPTION
## Summary
- Broaden content script URL patterns to match Amazon wishlist pages with optional localization segments before `hz/wishlist/ls`
- Document support for localized wishlist URLs in the README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab24404928832197ba399325bcf04b