### PR TITLE
Add build command for Chrome and Firefox bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+node_modules/
+dist/
 *.zip

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,10 @@
 The only difference between the chrome version and the firefox one is the manifest (v2 vs v3).
 
 This extension now supports localized Amazon wishlist URLs, including paths with
-segments like `-/en/hz/wishlist/ls/` so it works across different country and
+segments like '-/en/hz/wishlist/ls/' so it works across different country and
 language variants.
+
+Building
+--------
+
+Run `npm run build` to create `dist/chrome.zip` and `dist/firefox.zip`.

--- a/build.js
+++ b/build.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const rootDir = __dirname;
+const srcDir = path.join(rootDir, 'src');
+const distDir = path.join(rootDir, 'dist');
+
+fs.rmSync(distDir, { recursive: true, force: true });
+fs.mkdirSync(distDir, { recursive: true });
+
+function buildFirefox() {
+  const firefoxDir = path.join(distDir, 'firefox');
+  fs.cpSync(srcDir, firefoxDir, { recursive: true });
+  fs.rmSync(path.join(firefoxDir, 'manifest-chrome.json'), { force: true });
+  execSync('zip -r ../firefox.zip .', { cwd: firefoxDir, stdio: 'inherit' });
+  fs.rmSync(firefoxDir, { recursive: true, force: true });
+}
+
+function buildChrome() {
+  const chromeDir = path.join(distDir, 'chrome');
+  fs.cpSync(srcDir, chromeDir, { recursive: true });
+  fs.rmSync(path.join(chromeDir, 'manifest.json'), { force: true });
+  fs.renameSync(
+    path.join(chromeDir, 'manifest-chrome.json'),
+    path.join(chromeDir, 'manifest.json')
+  );
+  execSync('zip -r ../chrome.zip .', { cwd: chromeDir, stdio: 'inherit' });
+  fs.rmSync(chromeDir, { recursive: true, force: true });
+}
+
+buildFirefox();
+buildChrome();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "amazon-wishlist-extension",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "node build.js",
+    "test": "echo \"No tests\""
+  }
+}


### PR DESCRIPTION
## Summary
- add node build script to generate chrome and firefox extension zips
- wire up npm build/test scripts and document the workflow
- ignore dist output and zip archives

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e53ca5d88321a07b40ca842ad4e5